### PR TITLE
Add websocket listener to Mosquitto

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,3 +17,5 @@ services:
       - 1883:1883
       - 9001:9001
     container_name: mqtt
+    volumes:
+      - ./mosquitto.conf:/mosquitto/config/mosquitto.conf

--- a/mosquitto.conf
+++ b/mosquitto.conf
@@ -1,0 +1,7 @@
+# https://mosquitto.org/man/mosquitto-conf-5.html
+# Note that the order of settings is important!
+listener 1883
+protocol mqtt
+
+listener 9001
+protocol websockets


### PR DESCRIPTION
Enable websocket endpoint in development Mosquitto, so that the visualizer tool can connect to the bus.